### PR TITLE
Wrong order of left/right arrows

### DIFF
--- a/PythonApp/templates/index.html
+++ b/PythonApp/templates/index.html
@@ -13,11 +13,11 @@
         class="two cta"
       ></button>
       <button
-        onclick="window.location.href = '/?key=right';"
+        onclick="window.location.href = '/?key=left';"
         class="three cta"
       ></button>
       <button
-        onclick="window.location.href = '/?key=left';"
+        onclick="window.location.href = '/?key=right';"
         class="four cta"
       ></button>
 


### PR DESCRIPTION
I noticed when messing around with the website that the left and right arrows were connected to the opposite keys that they should have been.